### PR TITLE
Ship the WASM hero flow-field on the live site

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,13 +57,13 @@ Hybrid architecture: a thin JS host shell with a Rust/AssemblyScript→WASM core
 few genuinely compute/visual-heavy pieces. WASM is always lazy-loaded + capability-gated,
 and every feature keeps its existing JS/CSS fallback. See `assembly/`, `modules/wasm/`.
 
-| #   | Item                                                                                                | Status        |
-| --- | --------------------------------------------------------------------------------------------------- | ------------- |
-| 6.1 | WASM toolchain (AssemblyScript) wired into Vite build + lazy load (`asconfig.json`, `build:wasm`)   | ✅ 2026-06-28 |
-| 6.2 | Hero particle flow-field compute core in WASM (`assembly/hero-sim.ts` + `modules/wasm/hero-sim.js`) | ✅ 2026-06-28 |
-| 6.3 | `wasm-lab.html` interactive showcase + live FPS/particle HUD (measured: 3.5k particles @ 120fps)    | ✅ 2026-06-28 |
-| 6.4 | Wire the WASM hero behind the existing capability gate as an opt-in hero mode                       | ⬜            |
-| 6.5 | Edge OG images via a Rust WASM rasterizer (port `worker/og.js` → PNG), SVG kept as fallback         | ⬜            |
+| #   | Item                                                                                                                                                                                                | Status        |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| 6.1 | WASM toolchain (AssemblyScript) wired into Vite build + lazy load (`asconfig.json`, `build:wasm`)                                                                                                   | ✅ 2026-06-28 |
+| 6.2 | Hero particle flow-field compute core in WASM (`assembly/hero-sim.ts` + `modules/wasm/hero-sim.js`)                                                                                                 | ✅ 2026-06-28 |
+| 6.3 | `wasm-lab.html` interactive showcase + live FPS/particle HUD (measured: 3.5k particles @ 120fps)                                                                                                    | ✅ 2026-06-28 |
+| 6.4 | WASM hero shipped live: `initHeroEnhancements` mounts the flow-field first, falling back to the WebGL shader then CSS (`main.js`); transparent `destination-out` trails composite over the gradient | ✅ 2026-06-28 |
+| 6.5 | Edge OG images via a Rust WASM rasterizer (port `worker/og.js` → PNG), SVG kept as fallback                                                                                                         | ⬜            |
 
 ## Decision Log
 

--- a/main.js
+++ b/main.js
@@ -259,9 +259,12 @@ async function initializeApp() {
 }
 
 /**
- * Initialize hero text reveal + (capability-gated) WebGL mesh gradient.
- * Text effect is cheap and runs right away; the canvas chunk is lazy-loaded
- * and only runs when device capability allows.
+ * Initialize hero text reveal + (capability-gated) animated background.
+ * Text effect is cheap and runs right away. For the background we try the
+ * WebAssembly particle flow-field first (compute in WASM, paint in JS); if WASM
+ * is unavailable we fall back to the WebGL mesh-gradient shader, and if that
+ * also fails the static CSS gradient stays visible. Everything is lazy-loaded
+ * and only runs when device capability allows, so first paint is untouched.
  */
 async function initHeroEnhancements() {
     try {
@@ -272,7 +275,7 @@ async function initHeroEnhancements() {
     }
 
     try {
-        const { canRunHeavyEffects } = await import('./modules/capabilities.js');
+        const { canRunHeavyEffects, motion } = await import('./modules/capabilities.js');
         if (!canRunHeavyEffects()) {
             return; // CSS fallback gradient remains visible.
         }
@@ -280,6 +283,23 @@ async function initHeroEnhancements() {
         if (!canvas) {
             return;
         }
+
+        // Primary: WASM particle flow-field (transparent 2D canvas over the
+        // gradient). loadSim() throws before touching the canvas context if WASM
+        // can't load, so the element stays clean for the WebGL fallback below.
+        try {
+            const { mountHeroSim } = await import('./modules/wasm/hero-sim.js');
+            const wasmHandle = await mountHeroSim(canvas, { reducedMotion: motion.reduced });
+            if (wasmHandle) {
+                appState.managers.heroCanvas = wasmHandle;
+                canvas.classList.add('is-active');
+                return;
+            }
+        } catch (err) {
+            debug.warn('[App] WASM hero core skipped, trying WebGL shader:', err);
+        }
+
+        // Fallback: WebGL mesh-gradient shader.
         const { initHeroCanvas } = await import('./modules/hero-canvas.js');
         const handle = initHeroCanvas(canvas);
         if (handle) {

--- a/modules/wasm/hero-sim.js
+++ b/modules/wasm/hero-sim.js
@@ -56,7 +56,7 @@ async function loadSim() {
 /**
  * Mount the WASM particle field onto a canvas.
  * @param {HTMLCanvasElement} canvas
- * @param {{ density?: number, speed?: number, reducedMotion?: boolean }} [opts]
+ * @param {{ density?: number, speed?: number, reducedMotion?: boolean, trailFade?: number }} [opts]
  * @returns {Promise<HeroSimHandle | null>}
  */
 export async function mountHeroSim(canvas, opts = {}) {
@@ -79,6 +79,9 @@ export async function mountHeroSim(canvas, opts = {}) {
     const dpr = Math.min(globalThis.devicePixelRatio || 1, 2);
     const reduced = Boolean(opts.reducedMotion);
     const speed = opts.speed ?? 1.4;
+    // Trail persistence: higher = longer-lived trails. Erased via destination-out
+    // each frame so the canvas stays transparent over whatever is behind it.
+    const trailFade = opts.trailFade ?? 0.09;
     // Particles scale with area but stay capped so low-power devices stay smooth.
     const density = opts.density ?? 0.0009;
 
@@ -155,9 +158,12 @@ export async function mountHeroSim(canvas, opts = {}) {
             refreshView(); // memory grew → re-bind the view.
         }
 
-        // Fade previous frame for trails instead of hard clear.
-        ctx.globalCompositeOperation = 'source-over';
-        ctx.fillStyle = isDark() ? 'rgba(3, 6, 5, 0.06)' : 'rgba(255, 255, 255, 0.07)';
+        // Fade previous frame for trails. `destination-out` lowers the alpha of
+        // existing pixels (erasing old trails toward transparent) instead of
+        // painting an opaque veil, so the canvas composites cleanly over whatever
+        // sits behind it (e.g. the hero's animated gradient) in any theme.
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.fillStyle = `rgba(0, 0, 0, ${trailFade})`;
         ctx.fillRect(0, 0, width, height);
 
         ctx.globalCompositeOperation = 'lighter';

--- a/modules/wasm/hero-sim.js
+++ b/modules/wasm/hero-sim.js
@@ -79,9 +79,12 @@ export async function mountHeroSim(canvas, opts = {}) {
     const dpr = Math.min(globalThis.devicePixelRatio || 1, 2);
     const reduced = Boolean(opts.reducedMotion);
     const speed = opts.speed ?? 1.4;
-    // Trail persistence: higher = longer-lived trails. Erased via destination-out
+    // Trail persistence: lower = longer-lived trails. Erased via destination-out
     // each frame so the canvas stays transparent over whatever is behind it.
-    const trailFade = opts.trailFade ?? 0.09;
+    const trailFadeInput = Number(opts.trailFade ?? 0.09);
+    const trailFade = Number.isFinite(trailFadeInput)
+        ? Math.min(1, Math.max(0, trailFadeInput))
+        : 0.09;
     // Particles scale with area but stay capped so low-power devices stay smooth.
     const density = opts.density ?? 0.0009;
 


### PR DESCRIPTION
## What

Promotes the validated AssemblyScript particle flow-field from the `wasm-lab.html` demo to the **actual site hero**. This is the payoff of the WASM evaluation (PR #40): the compute core now runs where visitors see it.

## How

- **`main.js` (`initHeroEnhancements`)** — tries `mountHeroSim` first, behind the existing `canRunHeavyEffects()` capability gate. Layered fallback preserved:
  1. WASM particle flow-field (primary)
  2. WebGL mesh-gradient shader (if WASM can't load)
  3. Static CSS gradient (if neither runs / reduced-motion / low-power)

  `loadSim()` throws before touching the canvas context if WASM is unavailable, so the element stays clean for the WebGL fallback.

- **`modules/wasm/hero-sim.js`** — trails now fade via `destination-out` (erasing old pixels toward transparent) instead of an opaque per-frame fill. This lets the transparent particle canvas composite cleanly over the hero's animated gradient in **both light and dark themes** — the old opaque veil would have buried the gradient and washed out in light mode. Trail length is now configurable via a `trailFade` option.

## Verification

Confirmed live in Chrome (DPR 2): WASM path active, ~3.4k particles @ 120 fps, hero text fully legible. `wasm-lab.html` unchanged.

- ✅ `lint`
- ✅ `format:check`
- ✅ `build`
- ✅ 43 unit tests
- ✅ 15 E2E + a11y tests

## Notes

Branches off the latest `main` (includes the post-merge review-feedback commit `0b9dcd2`, whose `stride`/fetch-clone/pointer-guard changes are preserved). Remaining WASM roadmap item — edge OG rasterizer (6.5) — stays blocked on the Rust toolchain + Worker deploy access.