### PR TITLE
fix: replace fabricated job history with real resume data

### DIFF
--- a/experience-data.json
+++ b/experience-data.json
@@ -4,28 +4,75 @@
       "role": "Software Engineer",
       "company": "Deere & Company",
       "companyUrl": "https://www.deere.com",
-      "location": "Milan, IL",
-      "startDate": "2022-06",
+      "startDate": "2021",
       "endDate": null,
       "current": true,
-      "summary": "Building software at the intersection of agriculture and technology at one of the world's largest equipment manufacturers.",
+      "summary": "Aftermarket & Customer Support, Global Parts Information Technology — Parts Order Management Legacy & Dealer Business System Integrations Team. Support Java and SAP service parts order management applications, developing solutions for complex business challenges and partnering with the product manager to prioritize work that delivers clear value to the company and its dealers.",
       "highlights": [
-        "Designed and shipped production data pipelines processing sensor telemetry from field equipment",
-        "Contributed to internal platform tooling used across multiple engineering teams",
-        "Led adoption of TypeScript in a previously JavaScript codebase, improving type safety and DX"
+        "Converting legacy Java processes into APIs and microservices to make applications more scalable and easier to maintain",
+        "Building front-end interfaces in TypeScript and React to improve the user experience",
+        "Partnering directly with the Parts Order Management product manager to identify and prioritize work that delivers clear value to the company and its dealers"
       ],
-      "technologies": ["TypeScript", "Java", "Python"]
+      "technologies": ["Java", "SAP", "SAP ABAP", "SAP CPI", "TypeScript", "React"]
+    },
+    {
+      "role": "Business Analyst",
+      "company": "Deere & Company",
+      "companyUrl": "https://www.deere.com",
+      "startDate": "2013",
+      "endDate": "2021",
+      "current": false,
+      "summary": "Global Information Technology, Human Resources & Corporate Functions Domain — Corporate Functions & John Deere University Teams. Acting co-product manager for the Corporate Functions team, supporting Corporate Social Responsibility, Brand Management & Licensing, Public Affairs, Environmental Health & Safety, Aviation, and Facilities through the company's Agile reorganization.",
+      "highlights": [
+        "2021 — Provided direction as co-product manager during the transition to Agile, developing task boards, reports, and processes to guide daily standups and sprint planning",
+        "2018 — Built a Tableau project combining multiple CSR and HR data sources into a community scorecard used by facility leadership across 20+ global locations; all unit campaigns saw a marked percentage increase in giving in 2019",
+        "2016 — Led a development team building automated payroll deduction processes for charitable giving, significantly reducing manual processing time"
+      ],
+      "technologies": ["SAP", "Tableau", "SQL", "Excel"]
+    },
+    {
+      "role": "IT Early Development Program",
+      "company": "Deere & Company",
+      "companyUrl": "https://www.deere.com",
+      "startDate": "2009",
+      "endDate": "2013",
+      "current": false,
+      "summary": "Global Information Technology, Datacenter 24x7 Support & Dealer Systems Go-Live Support. A rotational program helping recent computer science graduates navigate different roles and business units within the company.",
+      "highlights": [
+        "2012 — Administered training for more than 50 dealer employees during a systems migration at two of the company's largest Construction & Forestry dealers, in Orlando, Florida and Bangor, Maine"
+      ],
+      "technologies": []
     }
   ],
   "education": [
     {
-      "degree": "B.A. Computer Science",
+      "degree": "B.A. Information Systems",
       "institution": "St. Ambrose University",
       "institutionUrl": "https://www.sau.edu",
       "location": "Davenport, IA",
-      "startDate": "2006-08",
-      "endDate": "2009-05",
+      "startDate": null,
+      "endDate": "2009",
       "highlights": []
+    },
+    {
+      "degree": "Graduate-level coursework, Computer Science",
+      "institution": "St. Ambrose University",
+      "institutionUrl": "https://www.sau.edu",
+      "location": "Davenport, IA",
+      "startDate": "2009",
+      "endDate": "2012",
+      "highlights": []
+    },
+    {
+      "degree": "Software Engineering Immersive",
+      "institution": "General Assembly",
+      "institutionUrl": "https://generalassemb.ly",
+      "location": null,
+      "startDate": "2021",
+      "endDate": "2021",
+      "highlights": [
+        "12-week immersive program sharpening full-stack development skills, including React, Node, and Express"
+      ]
     }
   ]
 }

--- a/modules/experience.js
+++ b/modules/experience.js
@@ -95,6 +95,7 @@ class ExperienceManager {
         const fmt = d => {
             if (!d) return '';
             const [year, month] = d.split('-');
+            if (!month) return year;
             const months = [
                 'Jan',
                 'Feb',
@@ -111,8 +112,9 @@ class ExperienceManager {
             ];
             return `${months[Number(month) - 1]} ${year}`;
         };
+        const start = fmt(startDate);
         const end = current ? 'Present' : fmt(endDate);
-        return `${fmt(startDate)} – ${end}`;
+        return start ? `${start} – ${end}` : end;
     }
 
     #highlightLi(text) {


### PR DESCRIPTION
## Description

`experience-data.json` had fabricated content: wrong dates (2022-06 vs. actual 2021), a wrong degree title (B.A. Computer Science vs. actual B.A. Information Systems), invented highlights ("sensor telemetry pipelines", "internal platform tooling") that don't appear anywhere in the real resume, and an invented education timeline with no source.

Replaced with the real work history sourced directly from the user's resume:
- **Software Engineer** (2021–present) — Aftermarket & Customer Support / Global Parts IT; converting legacy Java to APIs/microservices, building TypeScript/React front-ends
- **Business Analyst** (2013–2021) — new entry; Corporate Functions co-product manager, the 2018 Tableau CSR/HR dashboard project, the 2016 automated payroll-deduction system
- **IT Early Development Program** (2009–2013) — new entry; the 2012 dealer-migration training in Orlando and Bangor
- **Education** — corrected to B.A. Information Systems (2009) + graduate-level CS coursework (2009–2012) at St. Ambrose, plus the General Assembly Software Engineering Immersive (2021) that backs the pivot into engineering that year

Also fixes `modules/experience.js`'s date formatter, which assumed month-precision (`YYYY-MM`) dates and would render `undefined 2021` for year-only input. Since the resume only gives years, the formatter now displays bare years gracefully.

Out of scope (left for a future pass if wanted): Professional Training section (Boston College, Tableau courses) and Professional Affiliations & Community Service (IEEE, United Way, CASA/Youth Advocacy) from the resume weren't pulled in.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my code
- [x] Lint and tests pass locally (`pnpm validate`, `pnpm test:e2e` — 15/15 passing)
- [ ] I have updated documentation as needed (n/a)
- [x] I have not introduced any security vulnerabilities

## Screenshots

Rendered timeline (light theme):

Three work entries (Software Engineer, Business Analyst, IT Early Development Program) and three education entries (B.A. Information Systems, graduate coursework, General Assembly bootcamp) all render correctly with year-only date ranges, including the single-year "2009" case for the B.A. entry.